### PR TITLE
Add Nautilus Trader quickstart

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# siggen
+# Nautilus Trader Quickstart
+
+This project demonstrates how to run the [Nautilus Trader](https://nautilustrader.io/) quickstart example using Python and Jupyter notebooks. It also installs the [SnapTrade](https://snaptrade.com/) SDK for live execution.
+
+## Setup
+
+1. Install Python 3.11 or later.
+2. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Download sample FX data using the script provided by Nautilus Trader:
+   ```bash
+   curl https://raw.githubusercontent.com/nautechsystems/nautilus_data/main/nautilus_data/hist_data_to_catalog.py | python -
+   ```
+4. Launch Jupyter to explore the quickstart notebook:
+   ```bash
+   jupyter notebook
+   ```
+5. Alternatively run the script directly:
+   ```bash
+   python quickstart.py
+   ```
+
+## Tests
+
+Run the automated tests with:
+
+```bash
+pytest
+```

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+
+from nautilus_trader.backtest.node import (
+    BacktestDataConfig,
+    BacktestEngineConfig,
+    BacktestNode,
+    BacktestRunConfig,
+    BacktestVenueConfig,
+)
+from nautilus_trader.config import ImportableStrategyConfig, LoggingConfig
+from nautilus_trader.core.message import Event
+from nautilus_trader.indicators.macd import MovingAverageConvergenceDivergence
+from nautilus_trader.model import InstrumentId, Position, Quantity, QuoteTick, Venue
+from nautilus_trader.model.enums import OrderSide, PositionSide, PriceType
+from nautilus_trader.model.events import PositionOpened
+from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from nautilus_trader.trading.strategy import Strategy, StrategyConfig
+
+
+class MACDConfig(StrategyConfig):
+    """Configuration for the MACD strategy."""
+
+    instrument_id: InstrumentId
+    fast_period: int = 12
+    slow_period: int = 26
+    trade_size: int = 1_000_000
+    entry_threshold: float = 0.0001
+
+
+class MACDStrategy(Strategy):
+    """Simple MACD cross-over strategy."""
+
+    def __init__(self, config: MACDConfig) -> None:
+        super().__init__(config=config)
+        self.macd = MovingAverageConvergenceDivergence(
+            fast_period=config.fast_period,
+            slow_period=config.slow_period,
+            price_type=PriceType.MID,
+        )
+        self.trade_size = Quantity.from_int(config.trade_size)
+        self.position: Position | None = None
+
+    def on_start(self) -> None:
+        self.subscribe_quote_ticks(instrument_id=self.config.instrument_id)
+
+    def on_stop(self) -> None:
+        self.close_all_positions(self.config.instrument_id)
+        self.unsubscribe_quote_ticks(instrument_id=self.config.instrument_id)
+
+    def on_quote_tick(self, tick: QuoteTick) -> None:
+        self.macd.handle_quote_tick(tick)
+        if not self.macd.initialized:
+            return
+        self.check_for_entry()
+        self.check_for_exit()
+
+    def on_event(self, event: Event) -> None:
+        if isinstance(event, PositionOpened):
+            self.position = self.cache.position(event.position_id)
+
+    def open_position(self, side: OrderSide) -> None:
+        order = self.order_factory.market(
+            instrument_id=self.config.instrument_id,
+            order_side=side,
+            quantity=self.trade_size,
+        )
+        self.submit_order(order)
+
+    def check_for_entry(self) -> None:
+        value = self.macd.value
+        threshold = self.config.entry_threshold
+
+        if value > threshold and (
+            not self.position or self.position.side != PositionSide.LONG
+        ):
+            self.open_position(OrderSide.BUY)
+        elif value < -threshold and (
+            not self.position or self.position.side != PositionSide.SHORT
+        ):
+            self.open_position(OrderSide.SELL)
+
+    def check_for_exit(self) -> None:
+        if not self.position:
+            return
+
+        if self.macd.value >= 0.0 and self.position.side == PositionSide.SHORT:
+            self.close_position(self.position)
+        elif self.macd.value < 0.0 and self.position.side == PositionSide.LONG:
+            self.close_position(self.position)
+
+
+def run_backtest() -> None:
+    """Run the MACD backtest from the Nautilus Trader quickstart."""
+    catalog = ParquetDataCatalog.from_env()
+    instruments = catalog.instruments()
+
+    venue = BacktestVenueConfig(
+        name="SIM",
+        oms_type="NETTING",
+        account_type="MARGIN",
+        base_currency="USD",
+        starting_balances=["1_000_000 USD"],
+    )
+
+    data = BacktestDataConfig(
+        catalog_path=str(catalog.path),
+        data_cls=QuoteTick,
+        instrument_id=instruments[0].id,
+        end_time="2020-01-10",
+    )
+
+    engine = BacktestEngineConfig(
+        strategies=[
+            ImportableStrategyConfig(
+                strategy_path="__main__:MACDStrategy",
+                config_path="__main__:MACDConfig",
+                config={
+                    "instrument_id": instruments[0].id,
+                    "fast_period": 12,
+                    "slow_period": 26,
+                },
+            )
+        ],
+        logging=LoggingConfig(log_level="ERROR"),
+    )
+
+    config = BacktestRunConfig(
+        engine=engine,
+        venues=[venue],
+        data=[data],
+    )
+
+    node = BacktestNode(configs=[config])
+    results = node.run()
+    engine_instance = node.get_engine(config.id)
+    engine_instance.trader.generate_order_fills_report()
+    engine_instance.trader.generate_positions_report()
+    engine_instance.trader.generate_account_report(Venue("SIM"))
+    return results
+
+
+if __name__ == "__main__":
+    run_backtest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+nautilus-trader
+snaptrade
+jupyter
+pytest
+ruff

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from nautilus_trader.model.objects import Quantity
+from quickstart import MACDConfig, MACDStrategy
+
+
+def test_macd_config_defaults():
+    config = MACDConfig(instrument_id="EURUSD")
+    assert config.fast_period == 12
+    assert config.slow_period == 26
+    assert config.trade_size == 1_000_000
+    assert config.entry_threshold == 0.0001
+
+
+def test_strategy_initialization():
+    config = MACDConfig(instrument_id="EURUSD")
+    strat = MACDStrategy(config)
+    assert isinstance(strat.macd, object)
+    assert isinstance(strat.trade_size, Quantity)


### PR DESCRIPTION
## Summary
- add instructions for Nautilus Trader with SnapTrade
- implement MACD backtest script based on quickstart
- include tests for MACD config and strategy
- set up Python requirements
- refactor MACD strategy with helper method and simpler exit logic
- add GitHub Actions CI workflow

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688bc8a3bf4c8331b2f8d54f32921ef9